### PR TITLE
Batch load balanced traces by endpoint

### DIFF
--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -119,6 +119,7 @@ func (e *traceExporterImp) consumeTracesById(ctx context.Context, td ptrace.Trac
 			re = append(re, routingEntry{
 				routingKey: traceIDRouting,
 				keyValue:   tid,
+				trace:      t,
 			})
 		} else {
 			return err
@@ -271,6 +272,10 @@ func splitTracesByResourceAttr(batches ptrace.Traces, resourceKeys []string) (ma
 			keyValue:   key,
 			trace:      trace,
 		})
+	}
+
+	if len(result[traceIDRouting]) == 0 {
+		delete(result, traceIDRouting)
 	}
 
 	return result, nil


### PR DESCRIPTION
**Description:**

This PR batches traces consumed by the `loadbalancing` exporter based on their target endpoint. This also includes a refactoring of the trace splitting logic.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

### Relevant Batching Function

```go
func (e *traceExporterImp) batchByEndpoint(re []routingEntry) []routingEntry {
	traceMap := make(map[string]routingEntry)
	for _, entry := range re {
		endpoint := e.loadBalancer.Endpoint([]byte(entry.keyValue))
		if _, ok := traceMap[endpoint]; !ok {
			traceMap[endpoint] = routingEntry{
				routingKey: entry.routingKey,
				// We only need to store one keyValue since we expect all keyValues
				// grouped here to hash to the same endpoint
				keyValue: entry.keyValue,
				trace:    ptrace.NewTraces(),
			}
		}
		entry.trace.ResourceSpans().MoveAndAppendTo(traceMap[endpoint].trace.ResourceSpans())
	}
	var res []routingEntry
	for _, tm := range traceMap {
		res = append(res, tm)
	}
	return res
}
```

With this change, we should expect to see a maximum of `2 * num_of_endpoints` request per batch consumed by the `loadbalancing` exporter.